### PR TITLE
[파피] tecoble 이전으로 기존 댓글 동기화 필요 Issue (#416) 해결

### DIFF
--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -249,7 +249,7 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
               {config.showSubscribe && <Subscribe title={config.title} />}
             </article>
           </div>
-          <Utterances repo={'woowacourse/javable-comments'} />
+          <Utterances repo={'woowacourse/tecoble-comments'} />
         </main>
 
         <ReadNext


### PR DESCRIPTION
댓글 관리 레포지토리 이름 변경에 따른 utterances가 참조할 레포지토리 이름도 수정하는 PR입니다!

javable-comments 레포지토리 이름을 tecoble-comments로 수정해주신 후 merge해주시면 깔끔하게 반영될 것 같습니다!