### PR TITLE
[파피] 오픈 그래프 지원 미숙 Issue(#396) og:url tecoble 단어 중복 수정

### DIFF
--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -130,7 +130,7 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
         <meta property="og:type" content="article" />
         <meta property="og:title" content={post.frontmatter.title} />
         <meta property="og:description" content={post.frontmatter.excerpt || post.excerpt} />
-        <meta property="og:url" content={config.siteUrl + location.pathname} />
+        <meta property="og:url" content={location.href} />
         {post.frontmatter.image?.childImageSharp && (
           <meta
             property="og:image"
@@ -149,7 +149,7 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={post.frontmatter.title} />
         <meta name="twitter:description" content={post.frontmatter.excerpt || post.excerpt} />
-        <meta name="twitter:url" content={config.siteUrl + location.pathname} />
+        <meta name="twitter:url" content={location.href} />
         {post.frontmatter.image?.childImageSharp && (
           <meta
             name="twitter:image"


### PR DESCRIPTION
localhost로 띄워서 볼 때와 실제 배포 환경의 `location.pathname`이 다르기 때문에 og:url 태그에 중복 단어가 생기던 부분을 수정했습니다.