### PR TITLE
[와일더] 포스트 태그에 이미지 출처를 표기하는 기능 추가

### DIFF
--- a/src/content/post/2021-04-26-state-pattern.md
+++ b/src/content/post/2021-04-26-state-pattern.md
@@ -6,6 +6,7 @@ tags: ['design-pattern']
 date: '2021-04-26T12:00:00.000Z'
 draft: false
 image: ../teaser/emotion.png
+source: https://view.genial.ly/5eb18d77e4d83e0d37f2aa38/presentation-emociones-en-adolescentes
 ---
 
 ## 🥰 😁 😐 😩 🤬 😴

--- a/src/content/post/2021-05-10-stack-vs-deque.md
+++ b/src/content/post/2021-05-10-stack-vs-deque.md
@@ -6,6 +6,7 @@ tags: ['java', 'stack', 'deque']
 date: '2021-05-10T12:00:00.000Z'
 draft: false
 image: ../teaser/stack_vs_deque.jpg
+source: https://www.campingdelaplagebenodet.com/237-actualites/3019-fred-magic-spectacle-magie-loctudy.html
 ---
 
 ## 🤹‍♀️

--- a/src/content/post/2021-05-23-stream-api-basic.md
+++ b/src/content/post/2021-05-23-stream-api-basic.md
@@ -6,6 +6,7 @@ tags: ['stream']
 date: '2021-05-23T12:00:00.000Z'
 draft: false
 image: ../teaser/stream-api.png
+source: https://morioh.com/p/6b859b7a83e6
 ---
 
 Java 의 Stream API 사용 방법을 알아보자. 우아한테크코스 프리코스 과정에서 Stream API 를 사용해서 코드를 맛깔나게 구현하는 분들을 보면 괜스레 해야 할 것 같고, 유용해 보여서 흥미가 생긴다. 처음 보는 Stream API 를 어디에 사용할 수 있는지, 어떻게 사용할 수 있는지에 대해 살펴보자.

--- a/src/content/post/2021-06-20-optional-vs-null.md
+++ b/src/content/post/2021-06-20-optional-vs-null.md
@@ -6,6 +6,7 @@ tags: ['optional', 'null']
 date: '2021-06-20T12:00:00.000Z'
 draft: false
 image: ../teaser/optional-vs-null.png
+source: https://lns13301.github.io/github-blog
 ---
 
 런타임에서 발생하는 NullPointException 방어를 위해 만들어둔 로직체크는 코드의 가독성과 유지 보수성이 떨어진다. 어떻게 null 을 다루면 좋을 지에 대한 해결책을 함수형 언어에서 찾았다. 함수형 언어는 <b>존재하지 않을 수도 있는 값</b>에 대한 별도의 타입을 가지고 있다. 개발자들은 여러가지 API 를 통해 간접적으로 값에 접근할 수 있다. 자바는 함수형 언어로부터 영감을 받아  <b>자바 8</b>에 처음 Optional 이 도입 되었다.

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -57,6 +57,7 @@ interface PageTemplateProps {
         excerpt: string;
         tags: string[];
         author: Author[];
+        source: string;
       };
     };
     relatedPosts: {
@@ -99,6 +100,7 @@ export interface PageContext {
     draft?: boolean;
     tags: string[];
     author: Author[];
+    source: string;
   };
 }
 
@@ -232,6 +234,11 @@ const PageTemplate = ({ data, pageContext, location }: PageTemplateProps) => {
                     fluid={post.frontmatter.image.childImageSharp.fluid}
                     alt={post.frontmatter.title}
                   />
+                  {post.frontmatter.source !== null && (
+                    <div style={{ color: 'darkgray'}}>
+                      (자료 출처 : {post.frontmatter.source})
+                    </div>
+                  )}
                 </PostFullImage>
               )}
               {!post.frontmatter.image?.childImageSharp && (
@@ -492,6 +499,7 @@ export const query = graphql`
             }
           }
         }
+        source
       }
     }
     relatedPosts: allMarkdownRemark(


### PR DESCRIPTION
<img width="564" alt="12" src="https://user-images.githubusercontent.com/49058669/126867701-32de45c1-f14c-45d0-a3cd-fc7348d0d420.png">

게시글의 frontmatter 부분에 source 태그와 출처를 기입하면 자동으로 썸네일 하단에 출처가 표기됩니다.
해당 태그를 기입하지 않으면 이전과 마찬가지로 생략됩니다.

각 크루들이 올린 글에 사용된 썸네일 이미지 출처를 기입해야 합니다.

<img width="1066" alt="13" src="https://user-images.githubusercontent.com/49058669/126867759-e11e7492-b35b-4895-8ad1-ce4e8eecb55f.png">
